### PR TITLE
Add compatibility for newer bundler versions

### DIFF
--- a/lib/rails4_upgrade/gemfile.rb
+++ b/lib/rails4_upgrade/gemfile.rb
@@ -1,11 +1,12 @@
 require "set"
 require "rails4_upgrade/gem_dependency"
 require "rails4_upgrade/gem"
+require "rails4_upgrade/lockfile"
 
 module Rails4Upgrade
   class Gemfile
     def initialize(lockfile_io)
-      @lockfile = Bundler::LockfileParser.new(lockfile_io.read)
+      @lockfile = Lockfile.new(lockfile_io.read)
 
       @gems = Hash[@lockfile.specs.map { |spec|
         [

--- a/lib/rails4_upgrade/lockfile.rb
+++ b/lib/rails4_upgrade/lockfile.rb
@@ -1,0 +1,37 @@
+module Rails4Upgrade
+  # Encapsulates extraction of specs and dependencies from the Gemfile.lock
+  #
+  # This is because in Bundler v1.15.0 Bundler::LockfileParser#dependencies
+  # changed from an instance of Array to an instance of Hash.
+  class Lockfile
+    def initialize(lockfile_content)
+      @lockfile = Bundler::LockfileParser.new(lockfile_content)
+    end
+
+    def specs
+      @lockfile.specs
+    end
+
+    def dependencies
+      if bundler_version <= legacy_bundler_version
+        lockfile_dependencies
+      else
+        lockfile_dependencies.values
+      end
+    end
+
+    private
+
+    def bundler_version
+      ::Gem::Version.create(Bundler::VERSION)
+    end
+
+    def legacy_bundler_version
+      ::Gem::Version.create('1.14.6')
+    end
+
+    def lockfile_dependencies
+      @lockfile.dependencies
+    end
+  end
+end

--- a/spec/lockfile_spec.rb
+++ b/spec/lockfile_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+require 'bundler'
+
+require 'rails4_upgrade/lockfile'
+
+module Rails4Upgrade
+  describe Lockfile do
+    let(:gemfile_path) { File.join(File.dirname(__FILE__), "fixtures", "gemfiles", "Gemfile_with_devise.lock") }
+    let(:gemfile_content) { File.open(gemfile_path).read }
+
+    let(:bundler_lockfile) { Bundler::LockfileParser.new(gemfile_content) }
+
+    let(:lockfile) { Lockfile.new(gemfile_content) }
+
+    it "returns the same specs as the bundler lockfile" do
+      expect(lockfile.specs).to eq(bundler_lockfile.specs)
+    end
+
+    context "when using bundler >= 1.15.0" do
+      let(:lockfile_dependencies) { double('lockfile_dependencies') }
+
+      before(:each) {
+        lockfile.stub(:bundler_version => ::Gem::Version.create('1.15.0'))
+        lockfile.stub(:lockfile_dependencies => lockfile_dependencies)
+      }
+
+      it "returns the same dependencies as the bundler lockfile dependencies.values" do
+        lockfile_dependencies.should_receive(:values)
+        lockfile.dependencies
+      end
+    end
+
+    context "when using bundler < 1.15.0" do
+      let(:lockfile_dependencies) { double('lockfile_dependencies') }
+
+      before(:each) {
+        lockfile.stub(:bundler_version => ::Gem::Version.create('1.14.6'))
+        lockfile.stub(:lockfile_dependencies => lockfile_dependencies)
+      }
+
+      it "returns the same dependencies as the bundler lockfile dependencies" do
+        lockfile_dependencies.should_not_receive(:values)
+        lockfile.dependencies
+      end
+    end
+  end
+end


### PR DESCRIPTION
In Bundler v1.15.0 `LockfileParser#specs` changed from being an array to being a hash, which broke the rails4:check rake task.

This PR should fix this.

I have not, however, been able to figure out how to run the new `LockfileSpec` against multiple versions of bundler in the same run. But by manually forcing Ruby to use specific versions of Bundler, I've been able to successfully run the specs - and they're all green.

This fixes #5